### PR TITLE
Fixing VM IP address in vm array

### DIFF
--- a/run.py
+++ b/run.py
@@ -34,8 +34,8 @@ class Proxmox:
                 else:
                     ip_address = f"{self.ip_net_prefix}.{vmid}"
                     logging.info(f"Unable to lookup IP address for {vmid}. Using predicted address of {ip_address}")
-    
-                vm['ip_address'] = f"{self.ip_net_prefix}.{vmid}"
+
+                vm['ip_address'] = ip_address
             return vms
     
         except Exception as err:


### PR DESCRIPTION
This fix fixes a bug I found where the VM that was resolved is not what is set.

Example of the before code: 

```
INFO:root:IP address for 100 is 10.97.13.5
INFO:root:Updated or created record for jump01.domain.cloud (10.97.13.100)
```

After the code change:
```
INFO:root:IP address for 100 is 10.97.13.5
INFO:root:Updated or created record for jump01.domain.cloud (10.97.13.5)
```