### PR TITLE
removing FQDNs from VM names

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -219,8 +219,10 @@ async def sync_to_cloudflare(cloudflare_token, cloudflare_zone, cloudflare_dns_s
     tasks = []
     for vm in vms:
         if cloudflare_dns_subdomain:
-            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'].replace('.' + cloudflare_dns_subdomain + '.' + cloudflare_zone, '')}.{cloudflare_dns_subdomain}.{cloudflare_zone}", vm['ip_address'])))
+            vm['name'] = vm['name'].replace(f".{cloudflare_dns_subdomain}.{cloudflare_zone}", '')
+            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'}.{cloudflare_dns_subdomain}.{cloudflare_zone}", vm['ip_address'])))
         else:
+            vm['name'] = vm['name'].replace(f".{cloudflare_zone}", '')
             tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'].replace('.' + cloudflare_zone, '')}.{cloudflare_zone}", vm['ip_address'])))
     await asyncio.gather(*tasks)
 

--- a/app/run.py
+++ b/app/run.py
@@ -223,7 +223,7 @@ async def sync_to_cloudflare(cloudflare_token, cloudflare_zone, cloudflare_dns_s
             tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'}.{cloudflare_dns_subdomain}.{cloudflare_zone}", vm['ip_address'])))
         else:
             vm['name'] = vm['name'].replace(f".{cloudflare_zone}", '')
-            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'].replace('.' + cloudflare_zone, '')}.{cloudflare_zone}", vm['ip_address'])))
+            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'].{cloudflare_zone}", vm['ip_address'])))
     await asyncio.gather(*tasks)
 
 async def pull_from_proxmox(proxmox_url, proxmox_nodes, proxmox_token_name, proxmox_token, network):

--- a/app/run.py
+++ b/app/run.py
@@ -219,9 +219,9 @@ async def sync_to_cloudflare(cloudflare_token, cloudflare_zone, cloudflare_dns_s
     tasks = []
     for vm in vms:
         if cloudflare_dns_subdomain:
-            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name']}.{cloudflare_dns_subdomain}.{cloudflare_zone}", vm['ip_address'])))
+            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'].replace('.' + cloudflare_dns_subdomain + '.' + cloudflare_zone, '')}.{cloudflare_dns_subdomain}.{cloudflare_zone}", vm['ip_address'])))
         else:
-            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name']}.{cloudflare_zone}", vm['ip_address'])))
+            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'].replace('.' + cloudflare_zone, '')}.{cloudflare_zone}", vm['ip_address'])))
     await asyncio.gather(*tasks)
 
 async def pull_from_proxmox(proxmox_url, proxmox_nodes, proxmox_token_name, proxmox_token, network):

--- a/app/run.py
+++ b/app/run.py
@@ -220,10 +220,10 @@ async def sync_to_cloudflare(cloudflare_token, cloudflare_zone, cloudflare_dns_s
     for vm in vms:
         if cloudflare_dns_subdomain:
             vm['name'] = vm['name'].replace(f".{cloudflare_dns_subdomain}.{cloudflare_zone}", '')
-            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'}.{cloudflare_dns_subdomain}.{cloudflare_zone}", vm['ip_address'])))
+            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name']}.{cloudflare_dns_subdomain}.{cloudflare_zone}", vm['ip_address'])))
         else:
             vm['name'] = vm['name'].replace(f".{cloudflare_zone}", '')
-            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name'].{cloudflare_zone}", vm['ip_address'])))
+            tasks.append(asyncio.create_task(cf.update_record(f"{vm['name']}.{cloudflare_zone}", vm['ip_address'])))
     await asyncio.gather(*tasks)
 
 async def pull_from_proxmox(proxmox_url, proxmox_nodes, proxmox_token_name, proxmox_token, network):


### PR DESCRIPTION
Fixing an issue where if VMs contained a FQDN(for example, "test01.blah.tld") as part of it's name, the record would be created as "test01.blah.tld.blah.tld" instead of "test01.blah.tld".
