### PR TITLE
Multiple Networks Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # Proxmox Cloudflare Sync
 
-This application queries your Proxmox node(s) to retrieve a list of all VMs. It attempts to determine each VM's IP address and subsequently updates the corresponding A records on Cloudflare. If the VM's IP address cannot be discovered, the application generates a predicted IP address based on the VM's VMID, using it as the last octet of an IP address within the specified `NETWORK` range. This predicted IP address is then used to create or update the A record on Cloudflare, ensuring that the DNS records remain up-to-date even when the IP address of a VM cannot be directly determined.
+This application queries your Proxmox node(s) to retrieve a list of all VMs. It attempts to determine each VM's IP address and subsequently updates the corresponding A records on Cloudflare. If the VM's IP address cannot be discovered, the application generates a predicted IP address based on the VM's VMID, using it as the last octet of an IP address within the specified `PREDICT_NETWORK` range. This predicted IP address is then used to create or update the A record on Cloudflare, ensuring that the DNS records remain up-to-date even when the IP address of a VM cannot be directly determined.
 
 This tool is perfect for users who manage dynamic Proxmox VM environments and want to keep their Cloudflare DNS records current with minimal manual effort.
 
 ## Prerequisites
 
-- Docker and Docker Compose installed on the host
-- A Proxmox cluster with API access
-- A Cloudflare account with API access
+- Docker and Docker Compose installed on a host that can reach the Proxmox servers
+- A Proxmox cluster and an API token
+- A Cloudflare account and an API token
 
 ## Environment Variables
 
 - `DEBUG`: Set to "true" to enable debug logging. Default is "false".
-- `NETWORK`: The network range (CIDR notation) within which the VMs' IP addresses are expected to be discovered, e.g., `192.168.2.0/24`. Any discovered IP addresses that are outside of this range are ignored. This is also the network used when a predicted IP address must be created for a VM.
+- `VALID_NETWORKS`: A list of network ranges (CIDR notation) within which the VMs' IP addresses are expected to be discovered, e.g., `192.168.2.0/24`. Any discovered IP addresses that are outside one of these ranges are ignored.
+- `PREDICT_NETWORK`: This is the network (CIDR notation) used when a predicted IP address must be created for a VM.
+- `PREDICT_IP_ADDRESSES`: Turn on/off the prediction of IP addresses based on the VMID of a VM if the IP address can not be discovered via the Proxmox API.
+- `PREDICT_IP_ADDRESSES_VMID_BLACKLIST`: A list of Proxmox VM VMIDs that should NOT have prediction run (if the IP address can not be found). Useful if you have some VMs in a subnet other than the `PREDICT_NETWORK`. This will prevent creation of incorrect records in Cloudflare for them. 
 - `PROXMOX_URL`: The URL of your Proxmox server, e.g., `https://proxmox-server:8006`.
 - `PROXMOX_NODES_LIST`: A comma-separated list of Proxmox node names, e.g., `pve01,pve02`.
 - `PROXMOX_TOKEN_NAME`: The name of the Proxmox API token, e.g., `api-user@pam!main`.
@@ -30,7 +33,7 @@ This tool is perfect for users who manage dynamic Proxmox VM environments and wa
 git clone https://github.com/AndrewPaglusch/Proxmox-To-Cloudflare-Sync.git
 cd Proxmox-To-Cloudflare-Sync/
 ```
-2. Edit the `docker-compose.yml` file and set the environment variables as needed.
+2. Copy docker-compose.yml.EXAMPLE to docker-compose.yml and set the environment variables as needed.
 3. Start the container using Docker Compose:
 ```bash
 docker-compose up -d

--- a/app/config.ini.TEMPLATE
+++ b/app/config.ini.TEMPLATE
@@ -1,5 +1,7 @@
 [main]
-network: ${NETWORK}
+valid_networks: ${VALID_NETWORKS}
+predict_network: ${PREDICT_NETWORK}
+predict_ip_addresses: ${PREDICT_IP_ADDRESSES}
 debug: ${DEBUG}
 
 [proxmox]

--- a/app/config.ini.TEMPLATE
+++ b/app/config.ini.TEMPLATE
@@ -2,6 +2,7 @@
 valid_networks: ${VALID_NETWORKS}
 predict_network: ${PREDICT_NETWORK}
 predict_ip_addresses: ${PREDICT_IP_ADDRESSES}
+predict_ip_addresses_vmid_blacklist: ${PREDICT_IP_ADDRESSES_VMID_BLACKLIST}
 debug: ${DEBUG}
 
 [proxmox]
@@ -14,4 +15,3 @@ proxmox_token: ${PROXMOX_TOKEN}
 cloudflare_token: ${CLOUDFLARE_TOKEN}
 cloudflare_zone: ${CLOUDFLARE_ZONE}
 cloudflare_dns_subdomain: ${CLOUDFLARE_DNS_SUBDOMAIN}
-

--- a/app/run.py
+++ b/app/run.py
@@ -275,6 +275,7 @@ try:
       if net.num_addresses == 1:
           raise ValueError(f"You must give a network in X.X.X.X/Y format. Got {net}")
 
+    #TODO: Add predict_skip_vmids to config. Skip prediction of IP address for VM if it is in list
     predict_ip_addresses = config.get('main', 'predict_ip_addresses').lower() == "true"
     proxmox_url = config.get('proxmox', 'proxmox_url')
     proxmox_token_name = config.get('proxmox', 'proxmox_token_name')

--- a/docker-compose.yml.EXAMPLE
+++ b/docker-compose.yml.EXAMPLE
@@ -6,11 +6,12 @@ services:
     restart: always
     environment:
       DEBUG: "false"
-      VALID_NETWORKS: 192.168.2.0/24,192.168.3.0/24 #comma seperated
+      VALID_NETWORKS: 192.168.2.0/24,192.168.3.0/24 #comma separated
       PREDICT_NETWORK: 192.168.2.0/24
       PREDICT_IP_ADDRESSES: true
+      PREDICT_IP_ADDRESSES_VMID_BLACKLIST: #comma separated
       PROXMOX_URL: https://proxmox-server:8006
-      PROXMOX_NODES_LIST: pve01,pve02 #comma seperated
+      PROXMOX_NODES_LIST: pve01,pve02 #comma separated
       PROXMOX_TOKEN_NAME: api-user@pam!main
       PROXMOX_TOKEN: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       CLOUDFLARE_TOKEN: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/docker-compose.yml.EXAMPLE
+++ b/docker-compose.yml.EXAMPLE
@@ -6,7 +6,9 @@ services:
     restart: always
     environment:
       DEBUG: "false"
-      NETWORK: 192.168.2.0/24
+      VALID_NETWORKS: 192.168.2.0/24,192.168.3.0/24 #comma seperated
+      PREDICT_NETWORK: 192.168.2.0/24
+      PREDICT_IP_ADDRESSES: true
       PROXMOX_URL: https://proxmox-server:8006
       PROXMOX_NODES_LIST: pve01,pve02 #comma seperated
       PROXMOX_TOKEN_NAME: api-user@pam!main


### PR DESCRIPTION
This PR supports multiple networks. Before, this script expected only a single network that all VMs would be inside. This caused VMs inside other networks to get their DNS records changed to invalid (generated) IP addresses inside the "main" network.

This also fixes a bug that would happen when a VM would have a NIC without an IP address assigned.

